### PR TITLE
fix: error when running tests

### DIFF
--- a/lua/malleatus.lua
+++ b/lua/malleatus.lua
@@ -1,3 +1,6 @@
 local M = {}
 
+function M.setup(opts)
+end
+
 return M


### PR DESCRIPTION
The spec we pass to lazy.minit.setup has `opts={}`.  This caused an
error because LazyVim would load the plugin and try to call `setup` but
our module had no so function.

To avoid having setup called one must pass `opts = nil`, but this commit
instead adds a no-op setup function since that's closer to what we'll
want out of a shared functionality plugin.
